### PR TITLE
Set tail cursor comment

### DIFF
--- a/lib/mongoriver/abstract_persistent_tailer.rb
+++ b/lib/mongoriver/abstract_persistent_tailer.rb
@@ -8,7 +8,7 @@ module Mongoriver
   class AbstractPersistentTailer < Tailer
     def initialize(upstream, type, opts={})
       raise "You can't instantiate an AbstractPersistentTailer -- did you want PersistentTailer? " if self.class == AbstractPersistentTailer
-      super(upstream, type)
+      super(upstream, type, opts)
 
       @last_saved       = nil
       @batch            = opts[:batch]

--- a/lib/mongoriver/tailer.rb
+++ b/lib/mongoriver/tailer.rb
@@ -5,10 +5,10 @@ module Mongoriver
     attr_reader :upstream_conn
     attr_reader :oplog
 
-    def initialize(upstreams, type, oplog = "oplog.rs")
+    def initialize(upstreams, type, opts = {})
       @upstreams = upstreams
       @type = type
-      @oplog = oplog
+      @oplog = opts.fetch(:oplog, "oplog.rs")
       # This number seems high
       @conn_opts = {:op_timeout => 86400}
 

--- a/lib/mongoriver/tailer.rb
+++ b/lib/mongoriver/tailer.rb
@@ -9,6 +9,7 @@ module Mongoriver
       @upstreams = upstreams
       @type = type
       @oplog = opts.fetch(:oplog, "oplog.rs")
+      @comment = opts[:comment]
       # This number seems high
       @conn_opts = {:op_timeout => 86400}
 
@@ -71,8 +72,10 @@ module Mongoriver
 
       # Maybe if ts is old enough, just start from the beginning?
       query = (opts[:filter] || {}).merge({ 'ts' => { '$gte' => ts } })
+      query_opts = {:timeout => false}
+      query_opts[:comment] = @comment if @comment
 
-      oplog_collection.find(query, :timeout => false) do |oplog|
+      oplog_collection.find(query, query_opts) do |oplog|
         oplog.add_option(Mongo::Constants::OP_QUERY_TAILABLE)
         oplog.add_option(Mongo::Constants::OP_QUERY_OPLOG_REPLAY)
 


### PR DESCRIPTION
Specify a comment when creating mongoriver tailers that gets attached to the oplog tail query.

@nelhage: Not sure whether this conflicts with any mongoriver thoughts you have, so would appreciate a look.