### PR TITLE
Replace #tail_from with #tail method in AbstractPersistentTailer

### DIFF
--- a/lib/mongoriver/abstract_persistent_tailer.rb
+++ b/lib/mongoriver/abstract_persistent_tailer.rb
@@ -15,11 +15,9 @@ module Mongoriver
       @last_read        = nil
     end
 
-    def tail_from(ts, opts={})
-      if ts.nil?
-        ts = read_timestamp
-      end
-      super(ts, opts)
+    def tail(opts={})
+      opts[:from] ||= read_timestamp
+      super(opts)
     end
 
     def stream(limit=nil)


### PR DESCRIPTION
This was required because the `#tail` method is invoked in the parent `Tailer` class by `Stream#run_forever`. I personally would remove the `#tail_from` method to avoid confusion, but I'm going to leave that decision up to the maintainers.
