### PR TITLE
Do not depend on "bson_ext" unless we are running MRI.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,10 @@
 source 'https://rubygems.org'
 
+platforms :mri do
+  # Conditionally install bson_ext if we are running mri. This logic is
+  # replicated in the gemspec through an "extension" which install bson_ext
+  # if we are not running jruby.
+  gem "bson_ext"
+end
+
 gemspec

--- a/ext/install_bson_ext/extconf.rb
+++ b/ext/install_bson_ext/extconf.rb
@@ -1,0 +1,16 @@
+require 'rubygems'
+require 'rubygems/command.rb'
+require 'rubygems/dependency_installer.rb'
+
+inst = Gem::DependencyInstaller.new
+begin
+  unless RUBY_VERSION.include?("jruby")
+    inst.install "bson_ext"
+  end
+rescue
+  exit(1)
+end
+
+File.open(File.join(File.dirname(__FILE__), "Makefile"), "w") do |f|
+  f.write("install:\n\ttrue\n")
+end

--- a/mongoriver.gemspec
+++ b/mongoriver.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.version       = Mongoriver::VERSION
 
   gem.add_runtime_dependency('mongo', '>= 1.7')
-  gem.add_runtime_dependency('bson_ext')
+  gem.add_runtime_dependency('bson_ext') if $platform.to_s == 'ruby'
   gem.add_runtime_dependency('log4r')
 
   gem.add_development_dependency('rake')

--- a/mongoriver.gemspec
+++ b/mongoriver.gemspec
@@ -17,10 +17,11 @@ Gem::Specification.new do |gem|
   gem.version       = Mongoriver::VERSION
 
   gem.add_runtime_dependency('mongo', '>= 1.7')
-  gem.add_runtime_dependency('bson_ext') if $platform.to_s == 'ruby'
   gem.add_runtime_dependency('log4r')
 
   gem.add_development_dependency('rake')
   gem.add_development_dependency('minitest')
   gem.add_development_dependency('mocha', '>= 0.13')
+
+  gem.extensions = ["ext/install_bson_ext/extconf.rb"]
 end


### PR DESCRIPTION
The `bson_ext` gem tries to build a C extension, which plays poorly with JRuby. If we're not running MRI, I'd prefer to take the performance hit in exchange for greater compatibility with more exotic Rubies.

CC: @nelhage @ebroder @gdb 