### PR TITLE
Update the persistent timestamp even if there are no oplog entries

### DIFF
--- a/lib/mongoriver/tailer.rb
+++ b/lib/mongoriver/tailer.rb
@@ -42,9 +42,13 @@ module Mongoriver
       end
     end
 
+    def connection_config
+      @upstream_conn['admin'].command(:ismaster => 1)
+    end
+
     def ensure_upstream_replset!
       # Might be a better way to do this, but not seeing one.
-      config = @upstream_conn['admin'].command(:ismaster => 1)
+      config = connection_config
       unless config['setName']
         raise "Server at #{@upstream_conn.host}:#{@upstream_conn.port} is not running as a replica set"
       end


### PR DESCRIPTION
We use the oplog timestamp recorded in the db as an indicator of whether our
oplog tailers are up to date or not. However, on the rare occasion when we
have a totally idle database, the timestamps don't get updated.

This change ensures that the timestamp is updated, even when new entries
aren't being written to the oplog. As long as we grab the timestamp before
querying the oplog, if we then query the oplog and get no results, we know
there won't be any entries older than the current server timestamp.
