### PR TITLE
issue #9 - stream fails while trying to handle sparse indexes

### DIFF
--- a/lib/mongoriver/stream.rb
+++ b/lib/mongoriver/stream.rb
@@ -114,7 +114,13 @@ module Mongoriver
 
     def handle_create_index(spec)
       db_name, collection_name = parse_ns(spec['ns'])
-      index_key = spec['key'].map { |field, dir| [field, dir.round] }
+      index_key = spec['key'].map { |field, dir|
+        if dir.is_a? Numeric
+          [field, dir.round]
+        else
+          [field,dir]
+        end
+      }
       options = {}
 
       spec.each do |key, value|


### PR DESCRIPTION
Stream fails trying to call `round` on TrueClass, for sparse: true in the key of an index. This PR checks that the value of the hash is numeric before trying to round it. 

If the key of the index contains: `"key" : { "some.document.field" : 1, "sparse" : true }`
Then stream will send the following to the outlet in the trigger (`index_key.to_s`): `[["some.document.field", 1], ["sparse", true]]`
