### PR TITLE
Support breaking out of stream in persistent tailer

### DIFF
--- a/lib/mongoriver/abstract_persistent_tailer.rb
+++ b/lib/mongoriver/abstract_persistent_tailer.rb
@@ -33,8 +33,8 @@ module Mongoriver
 
       # Sketchy logic - yield results from Tailer.stream
       # if nothing is found and nothing in cursor, save the current position
-      entries_left = super(limit) do |entry|
-        yield entry
+      entries_left = super(limit) do |entry, state|
+        yield(entry, state)
 
         found_entry = true
         @last_read = state_for(entry)

--- a/lib/mongoriver/tailer.rb
+++ b/lib/mongoriver/tailer.rb
@@ -97,7 +97,7 @@ module Mongoriver
     end
 
     def connection_config
-      @upstream_conn['admin'].command(:ismaster => 1)
+      @upstream_conn.db('admin').command(:ismaster => 1)
     end
 
     def ensure_upstream_replset!

--- a/lib/mongoriver/version.rb
+++ b/lib/mongoriver/version.rb
@@ -1,3 +1,3 @@
 module Mongoriver
-  VERSION = "0.4.4"
+  VERSION = "0.4.5"
 end

--- a/test/cursor_stub.rb
+++ b/test/cursor_stub.rb
@@ -1,0 +1,33 @@
+require 'mongo'
+
+class CursorStub
+  def initialize
+    @events = []
+    @index = 0
+  end
+
+  def add_option(opt) end
+
+  def generate_ops(max)
+    @index = 0
+    (1..max).map do |id|
+      @events << {
+        'ts' => BSON::Timestamp.new(Time.now.to_i, 0),
+        'ns' => 'foo.bar',
+        'op' => 'i',
+        'o'  => {
+          '_id' => id.to_s
+        }
+      }
+    end
+  end
+
+  def has_next?
+    @index < @events.length
+  end
+
+  def next
+    @index += 1
+    @events[@index - 1]
+  end
+end

--- a/test/test_tailer.rb
+++ b/test/test_tailer.rb
@@ -2,40 +2,9 @@ require 'minitest/autorun'
 require 'mocha/setup'
 require 'mongo'
 require 'mongoriver'
-
+require_relative './cursor_stub'
+  
 describe 'Mongoriver::Tailer' do
-  class CursorStub
-    def initialize
-      @events = []
-      @index = 0
-    end
-
-    def add_option(opt) end
-
-    def generate_ops(max)
-      @index = 0
-      (1..max).map do |id|
-        @events << {
-          'ts' => BSON::Timestamp.new(Time.now.to_i, 0),
-          'ns' => 'foo.bar',
-          'op' => 'i',
-          'o'  => {
-            '_id' => id.to_s
-          }
-        }
-      end
-    end
-
-    def has_next?
-      @index < @events.length
-    end
-
-    def next
-      @index += 1
-      @events[@index - 1]
-    end
-  end
-
   before do
     cursor = CursorStub.new
     collection = stub do


### PR DESCRIPTION
cc @qhduong-stripe @karla-stripe @bryan-stripe 

To make it possible to break out of stream (see previous commit https://github.com/stripe/mongoriver/commit/ae548a563563c29321991bfbecb720d6a440d05e) - need to add the same support in persistent tailer, which overrides stream method.