### PR TITLE
Mongo driver 2 support + createIndexes fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ this to resume interrupted tailers so that no information is lost.
 
 ## Version history
 
+### 0.5
+
+Move from the Moped driver to the native Mongo 2.0 driver.
+
 ### 0.4
 
 Add support for [tokumx](http://www.tokutek.com/products/tokumx-for-mongodb/). Backwards incompatible changes to persistent tailers to accomodate that. See [UPGRADING.md](UPGRADING.md).

--- a/lib/mongoriver/stream.rb
+++ b/lib/mongoriver/stream.rb
@@ -101,39 +101,9 @@ module Mongoriver
       end
     end
 
-    def handle_create_index(spec)
-      db_name, collection_name = parse_ns(spec['ns'])
-      index_key = spec['key'].map do |field, dir|
-        if dir.is_a?(Numeric)
-          [field, dir.round]
-        else
-          [field, dir]
-        end
-      end
-      options = {}
-
-      spec.each do |key, value|
-        case key
-        when 'v'
-          unless value == 1
-            raise NotImplementedError.new("Only v=1 indexes are supported, " \
-                                          "not v=#{value.inspect}")
-          end
-        when 'ns', 'key', '_id' # do nothing
-        else
-          options[key.to_sym] = value
-        end
-      end
-
-      assert(options.include?(:name),
-             "No name defined for index spec #{spec.inspect}")
-
-      trigger(:create_index, db_name, collection_name, index_key, options)
-    end
-
     def handle_cmd(db_name, collection_name, data)
-      if created_index = data['createIndexes']
-        trigger(:create_index, db_name, created_index, data)
+      if data['createIndexes']
+        handle_create_index(data)
       elsif deleted_from_collection = data['deleteIndexes']
         index_name = data['index']
         trigger(:drop_index, db_name, deleted_from_collection, index_name)
@@ -160,6 +130,37 @@ module Mongoriver
       end
 
       trigger(:create_collection, db_name, collection_name, options)
+    end
+
+    def handle_create_index(spec)
+      db_name, collection_name = parse_ns(spec['createIndexes'] || spec['ns'])
+
+      index_key = spec['key'].map do |field, dir|
+        if dir.is_a?(Numeric)
+          [field, dir.round]
+        else
+          [field, dir]
+        end
+      end
+      options = {}
+
+      spec.each do |key, value|
+        case key
+        when 'v'
+          unless value <= 2
+            raise NotImplementedError.new("Only v=1 and 2 indexes are supported, " \
+                                          "not v=#{value.inspect}")
+          end
+        when 'createIndexes', 'ns', 'key', '_id' # do nothing
+        else
+          options[key.to_sym] = value
+        end
+      end
+
+      assert(options.include?(:name),
+             "No name defined for index spec #{spec.inspect}")
+
+      trigger(:create_index, db_name, collection_name, index_key, options)
     end
   end
 end

--- a/lib/mongoriver/stream.rb
+++ b/lib/mongoriver/stream.rb
@@ -134,7 +134,7 @@ module Mongoriver
     def handle_cmd(db_name, collection_name, data)
       if created_index = data['createIndexes']
         trigger(:create_index, db_name, created_index, data)
-      if deleted_from_collection = data['deleteIndexes']
+      elsif deleted_from_collection = data['deleteIndexes']
         index_name = data['index']
         trigger(:drop_index, db_name, deleted_from_collection, index_name)
       elsif created_collection = data['create']

--- a/lib/mongoriver/stream.rb
+++ b/lib/mongoriver/stream.rb
@@ -132,6 +132,8 @@ module Mongoriver
     end
 
     def handle_cmd(db_name, collection_name, data)
+      if created_index = data['createIndexes']
+        trigger(:create_index, db_name, created_index, data)
       if deleted_from_collection = data['deleteIndexes']
         index_name = data['index']
         trigger(:drop_index, db_name, deleted_from_collection, index_name)

--- a/lib/mongoriver/tailer.rb
+++ b/lib/mongoriver/tailer.rb
@@ -70,9 +70,9 @@ module Mongoriver
 
       case database_type
       when :mongo
-        record = oplog_collection.find_one(query, :sort => [['$natural', -1]])
+        record = oplog_collection.find(query).sort( {'$natural' => -1 } ).limit(1).first
       when :toku
-        record = oplog_collection.find_one(query, :sort => [['_id', -1]])
+        record = oplog_collection.find(query).sort( {'_id' => -1} ).limit(1).first
       end
       record
     end
@@ -84,12 +84,11 @@ module Mongoriver
         @upstream_conn = Mongo::ReplSetConnection.new(@upstreams, opts)
       when :slave, :direct
         opts = @conn_opts.merge(:slave_ok => true)
-        host, port = parse_direct_upstream
-        @upstream_conn = Mongo::Connection.new(host, port, opts)
+        @upstream_conn = Mongo::Client.new(@upstreams[0], opts)
         raise "Server at #{@upstream_conn.host}:#{@upstream_conn.port} is the primary -- if you're ok with that, check why your wrapper is passing :direct rather than :slave" if @type == :slave && @upstream_conn.primary?
         ensure_upstream_replset!
       when :existing
-        raise "Must pass in a single existing Mongo::Connection with :existing" unless @upstreams.length == 1 && @upstreams[0].respond_to?(:db)
+        raise "Must pass in a single existing Mongo::Connection with :existing" unless @upstreams.length == 1 && @upstreams[0].respond_to?(:use)
         @upstream_conn = @upstreams[0]
       else
         raise "Invalid connection type: #{@type.inspect}"
@@ -97,7 +96,7 @@ module Mongoriver
     end
 
     def connection_config
-      @upstream_conn.db('admin').command(:ismaster => 1)
+      @upstream_conn.use('admin').command(:ismaster => 1).documents.first
     end
 
     def ensure_upstream_replset!
@@ -108,46 +107,27 @@ module Mongoriver
       end
     end
 
-    def parse_direct_upstream
-      raise "When connecting directly to a mongo instance, must provide a single upstream" unless @upstreams.length == 1
-      upstream = @upstreams[0]
-      parse_host_spec(upstream)
-    end
-
-    def parse_host_spec(host_spec)
-      host, port = host_spec.split(':')
-      host = '127.0.0.1' if host.to_s.length == 0
-      port = '27017' if port.to_s.length == 0
-      [host, port.to_i]
-    end
-
     def oplog_collection
-      @upstream_conn.db('local').collection(oplog)
+      @upstream_conn.use('local')[oplog]
     end
 
     # Start tailing the oplog.
-    # 
+    #
     # @param [Hash]
-    # @option opts [BSON::Timestamp, BSON::Binary] :from Placeholder indicating 
+    # @option opts [BSON::Timestamp, BSON::Binary] :from Placeholder indicating
     #           where to start the query from. Binary value is used for tokumx.
     #           The timestamp is non-inclusive.
     # @option opts [Hash] :filter Extra filters for the query.
-    # @option opts [Bool] :dont_wait(false) 
+    # @option opts [Bool] :dont_wait(false)
     def tail(opts = {})
       raise "Already tailing the oplog!" if @cursor
 
       query = build_tail_query(opts)
 
-      mongo_opts = {:timeout => false}.merge(opts[:mongo_opts] || {})
-
-      oplog_collection.find(query, mongo_opts) do |oplog|
-        oplog.add_option(Mongo::Constants::OP_QUERY_TAILABLE)
-        oplog.add_option(Mongo::Constants::OP_QUERY_OPLOG_REPLAY) if query['ts']
-        oplog.add_option(Mongo::Constants::OP_QUERY_AWAIT_DATA) unless opts[:dont_wait]
-
-        log.debug("Starting oplog stream from #{opts[:from] || 'start'}")
-        @cursor = oplog
-      end
+      cursor_type = opts[:dont_wait] ? :tailable : :tailable_await
+      oplog_replay = query['ts'] ? true : false
+      mongo_opts = {:timeout => false, :cursor_type => cursor_type, :oplog_replay => oplog_replay}.merge(opts[:mongo_opts] || {})
+      @cursor = oplog_collection.find(query, mongo_opts).to_enum.lazy
     end
 
     # Deprecated: use #tail(:from => ts, ...) instead
@@ -161,10 +141,9 @@ module Mongoriver
     end
 
     def stream(limit=nil, &blk)
-      count = 0
       @streaming = true
       state = TailerStreamState.new(limit)
-      while !@stop && !state.break? && @cursor.has_next?
+      while !@stop && !state.break? && cursor_has_more?
         state.increment
 
         record = @cursor.next
@@ -180,8 +159,7 @@ module Mongoriver
         end
       end
       @streaming = false
-
-      return @cursor.has_next?
+      return cursor_has_more?
     end
 
     def stop
@@ -211,6 +189,15 @@ module Mongoriver
       end
 
       query
+    end
+
+    def cursor_has_more?
+      begin
+        @cursor.peek
+        true
+      rescue StopIteration
+        false
+      end
     end
   end
 end

--- a/lib/mongoriver/toku.rb
+++ b/lib/mongoriver/toku.rb
@@ -1,10 +1,11 @@
 module Mongoriver
-  # This module deals with converting TokuMX oplog records into mongodb oplogs. 
+  # This module deals with converting TokuMX oplog records into mongodb oplogs.
   class Toku
-    # @returns true if conn is a TokuMX database and the oplog records need to 
-    #               be converted 
+    # @returns true if conn is a TokuMX database and the oplog records need to
+    #               be converted
     def self.conversion_needed?(conn)
-      conn.server_info.has_key? "tokumxVersion"
+      server_info = conn.command({:buildinfo => 1}).documents.first
+      server_info.has_key? "tokumxVersion"
     end
 
     def self.operations_for(record, conn=nil)
@@ -19,7 +20,7 @@ module Mongoriver
     end
 
     # Convert hash representing a tokumx oplog record to mongodb oplog records.
-    # 
+    #
     # Things to note:
     #   1) Unlike mongo oplog, the timestamps will not be monotonically
     #      increasing
@@ -71,7 +72,7 @@ module Mongoriver
         "op" => "i",
         # namespace being updated. in form of database-name.collection.name
         "ns" => operation["ns"],
-        # operation being done. 
+        # operation being done.
         # e.g. {"_id"=>BSON::ObjectId('53fb8f6b9e126b2106000003')}
         "o" => operation["o"]
       }

--- a/lib/mongoriver/version.rb
+++ b/lib/mongoriver/version.rb
@@ -1,3 +1,3 @@
 module Mongoriver
-  VERSION = "0.4.5"
+  VERSION = "0.5.0"
 end

--- a/mongoriver.gemspec
+++ b/mongoriver.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Mongoriver::VERSION
 
-  gem.add_runtime_dependency('mongo', ['>= 1.12.5', '< 2.0'])
-  gem.add_runtime_dependency('bson_ext', ['>= 1.12.5', '< 2.0'])
+  gem.add_runtime_dependency('mongo', '>= 2.0')
+  gem.add_runtime_dependency('bson_ext')
   gem.add_runtime_dependency('log4r')
 
   gem.add_development_dependency('rake')

--- a/test/cursor_stub.rb
+++ b/test/cursor_stub.rb
@@ -1,6 +1,8 @@
 require 'mongo'
 
 class CursorStub
+  include Enumerable
+
   def initialize
     @events = []
     @index = 0
@@ -29,5 +31,11 @@ class CursorStub
   def next
     @index += 1
     @events[@index - 1]
+  end
+
+  def each(&block)
+    @events.each do |event|
+      block.call(event)
+    end
   end
 end

--- a/test/test_mongoriver.rb
+++ b/test/test_mongoriver.rb
@@ -10,7 +10,9 @@ describe 'Mongoriver::Stream' do
   end
 
   before do
-    conn = stub(:db => nil, :server_info => {})
+    conn = stub(:use => nil)
+    buildinfo_command = stub(:documents => [{}])
+    conn.expects(:command).with(:buildinfo => 1).returns(buildinfo_command)
     @tailer = Mongoriver::Tailer.new([conn], :existing)
     @outlet = Mongoriver::AbstractOutlet.new
     @stream = Mongoriver::Stream.new(@tailer, @outlet)

--- a/test/test_tailer.rb
+++ b/test/test_tailer.rb
@@ -3,19 +3,14 @@ require 'mocha/setup'
 require 'mongo'
 require 'mongoriver'
 require_relative './cursor_stub'
-  
+
 describe 'Mongoriver::Tailer' do
   before do
     cursor = CursorStub.new
-    collection = stub do
-      expects(:find).yields(cursor)
-    end
-    db = stub do
-      expects(:collection).with('oplog.rs').returns(collection)
-    end
-    conn = stub(server_info: {}) do
-      expects(:db).with('local').returns(db)
-    end
+    collection = stub(:find => cursor)
+    buildinfo = stub(:documents => [{}])
+    conn = stub(:command => buildinfo)
+    conn.expects(:use).with('local').returns({'oplog.rs' => collection})
     @cursor = cursor
     @tailer = Mongoriver::Tailer.new([conn], :existing)
     @tailer.tail

--- a/test/test_toku.rb
+++ b/test/test_toku.rb
@@ -25,7 +25,9 @@ describe 'Mongoriver::Toku' do
 
   describe 'conversions sent to stream' do
     before do
-      conn = stub(:db => nil, :server_info => {'tokumxVersion' => '1'})
+      buildinfo = stub(:documents => [{'buildinfo' => '1'}]) # garbage
+      conn = stub(:use => nil, :command => buildinfo)
+
       @tailer = Mongoriver::Tailer.new([conn], :existing)
       @outlet = Mongoriver::AbstractOutlet.new
       @stream = Mongoriver::Stream.new(@tailer, @outlet)
@@ -93,7 +95,7 @@ describe 'Mongoriver::Toku' do
         'ns' => 'foo.$cmd',
         'o' => {'create' => 'bar', 'capped' => true, 'size' => 10}
       }))
-    end 
+    end
   end
 
   describe 'large transactions are joined by convert' do

--- a/test/test_toku.rb
+++ b/test/test_toku.rb
@@ -25,8 +25,8 @@ describe 'Mongoriver::Toku' do
 
   describe 'conversions sent to stream' do
     before do
-      buildinfo = stub(:documents => [{'buildinfo' => '1'}]) # garbage
-      conn = stub(:use => nil, :command => buildinfo)
+      server_info = stub(:documents => [ {'tokumxVersion' => '2'} ])
+      conn = stub(:use => nil, :command => server_info)
 
       @tailer = Mongoriver::Tailer.new([conn], :existing)
       @outlet = Mongoriver::AbstractOutlet.new


### PR DESCRIPTION
Based on Pull Request #19 and also fixes an error with the "createIndexes" command in a backwards-compatible fashion (previously was done as insert; now it's a cmd)